### PR TITLE
Add body parameters support in requests (#2). Add iOS platforms to CI (#9)

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -12,8 +12,14 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
-    - name: Build
+    - name: Build for macOS
       run: swift build -v
 
-    - name: Run unit tests
+    - name: Run unit tests for macOS
       run: swift test -v
+
+    - name: Build for iOS
+      run: set -o pipefail && env NSUnbufferedIO=YES xcodebuild build-for-testing -scheme Network-Package -destination "platform=iOS Simulator,OS=latest,name=iPhone 14" | xcpretty
+  
+    - name: Run iOS tests
+      run: set -o pipefail && env NSUnbufferedIO=YES xcodebuild test-without-building -scheme Network-Package -destination "platform=iOS Simulator,OS=latest,name=iPhone 12" | xcpretty

--- a/Sources/Network/Core/NetworkClientFactory.swift
+++ b/Sources/Network/Core/NetworkClientFactory.swift
@@ -5,6 +5,7 @@ public struct NetworkClientFactoryImpl: NetworkClientFactory {
     public init() {}
 
     public func networkClient(with session: URLSessionProtocol) -> NetworkClient {
-        NetworkClientImpl(session: session, requestAdapter: NetworkRequestAdapterImpl())
+		let adapter = StandardNetworkRequestAdapter(parametersEncoder: StandardRequestParametersEncoder())
+        return NetworkClientImpl(session: session, requestAdapter: adapter)
     }
 }

--- a/Sources/Network/Core/NetworkClientFactory.swift
+++ b/Sources/Network/Core/NetworkClientFactory.swift
@@ -5,7 +5,8 @@ public struct NetworkClientFactoryImpl: NetworkClientFactory {
     public init() {}
 
     public func networkClient(with session: URLSessionProtocol) -> NetworkClient {
-		let adapter = StandardNetworkRequestAdapter(parametersEncoder: StandardRequestParametersEncoder())
+		let parametersEncoder = StandardRequestParametersEncoder(bodyEncoder: JSONEncoder())
+		let adapter = StandardNetworkRequestAdapter(parametersEncoder: parametersEncoder)
         return NetworkClientImpl(session: session, requestAdapter: adapter)
     }
 }

--- a/Sources/Network/Core/NetworkRequestAdapter.swift
+++ b/Sources/Network/Core/NetworkRequestAdapter.swift
@@ -1,7 +1,9 @@
 import Foundation
 import NetworkAPI
 
-struct NetworkRequestAdapterImpl: NetworkRequestAdapter {
+/// A ``NetworkRequestAdapter`` with default behaviour.
+struct StandardNetworkRequestAdapter: NetworkRequestAdapter {
+	let parametersEncoder: ParametersEncoder
 
     // MARK: - Methods
 
@@ -11,38 +13,9 @@ struct NetworkRequestAdapterImpl: NetworkRequestAdapter {
         }
         var urlRequest = URLRequest(url: url)
         urlRequest.httpMethod = request.method.rawValue
-
-        if let parameters = request.parameters {
-            try add(parameters, to: &urlRequest)
-        }
+		if let parameters = request.parameters {
+			try parametersEncoder.encode(parameters: parameters, in: &urlRequest)
+		}
         return urlRequest
-    }
-
-    private func add(_ parameters: RequestParameter, to urlRequest: inout URLRequest) throws {
-        switch parameters {
-        case let .query(parameters):
-            try add(parameters.asQueryItems, to: &urlRequest)
-        }
-    }
-
-    private func add(_ queryItems: [URLQueryItem], to urlRequest: inout URLRequest) throws {
-        guard
-            let url = urlRequest.url,
-            var components = URLComponents(url: url, resolvingAgainstBaseURL: false)
-        else {
-            throw NetworkError.invalidRequestURL
-        }
-        components.queryItems = queryItems
-        urlRequest.url = components.url
-    }
-}
-
-// MARK: - Helpers
-
-private extension Dictionary<String, Any> {
-    var asQueryItems: [URLQueryItem] {
-        map { (key, value) in
-            URLQueryItem(name: key, value: "\(value)".addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed))
-        }
     }
 }

--- a/Sources/Network/ParametersEncoder/StandardRequestParametersEncoder.swift
+++ b/Sources/Network/ParametersEncoder/StandardRequestParametersEncoder.swift
@@ -2,11 +2,10 @@ import Foundation
 import NetworkAPI
 
 struct StandardRequestParametersEncoder: ParametersEncoder {
-	private let jsonEncoder: JSONEncoder
+	private let bodyEncoder: JSONEncoder
 
-	init() {
-		self.jsonEncoder = JSONEncoder()
-		jsonEncoder.outputFormatting = [.sortedKeys]
+	init(bodyEncoder: JSONEncoder) {
+		self.bodyEncoder = bodyEncoder
 	}
 
 	func encode(parameters: RequestParameter, in request: inout URLRequest) throws {
@@ -16,7 +15,7 @@ struct StandardRequestParametersEncoder: ParametersEncoder {
 			try add(queryItems, to: &request)
 
 		case let .body(encodable):
-			request.httpBody = try jsonEncoder.encode(encodable)
+			request.httpBody = try bodyEncoder.encode(encodable)
 		}
 	}
 

--- a/Sources/Network/ParametersEncoder/StandardRequestParametersEncoder.swift
+++ b/Sources/Network/ParametersEncoder/StandardRequestParametersEncoder.swift
@@ -27,7 +27,7 @@ struct StandardRequestParametersEncoder: ParametersEncoder {
 
 // MARK: - Helpers
 
-private extension Dictionary<String, Any> {
+private extension Dictionary where Key == String {
 	var asQueryItems: [URLQueryItem]? {
 		map { (key, value) in
 			URLQueryItem(name: key, value: "\(value)".addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed))

--- a/Sources/Network/ParametersEncoder/StandardRequestParametersEncoder.swift
+++ b/Sources/Network/ParametersEncoder/StandardRequestParametersEncoder.swift
@@ -1,0 +1,36 @@
+import Foundation
+import NetworkAPI
+
+struct StandardRequestParametersEncoder: ParametersEncoder {
+	func encode(parameters: RequestParameter, in request: inout URLRequest) throws {
+		switch parameters {
+		case let .query(dictionary):
+			guard let queryItems = dictionary.asQueryItems else { return }
+			try add(queryItems, to: &request)
+
+		case let .body(encodale):
+			return
+		}
+	}
+
+	private func add(_ queryItems: [URLQueryItem], to urlRequest: inout URLRequest) throws {
+		guard
+			let url = urlRequest.url,
+			var components = URLComponents(url: url, resolvingAgainstBaseURL: false)
+		else {
+			throw NetworkError.invalidRequestURL
+		}
+		components.queryItems = queryItems
+		urlRequest.url = components.url
+	}
+}
+
+// MARK: - Helpers
+
+private extension Dictionary<String, Any> {
+	var asQueryItems: [URLQueryItem]? {
+		map { (key, value) in
+			URLQueryItem(name: key, value: "\(value)".addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed))
+		}
+	}
+}

--- a/Sources/Network/ParametersEncoder/StandardRequestParametersEncoder.swift
+++ b/Sources/Network/ParametersEncoder/StandardRequestParametersEncoder.swift
@@ -2,14 +2,21 @@ import Foundation
 import NetworkAPI
 
 struct StandardRequestParametersEncoder: ParametersEncoder {
+	private let jsonEncoder: JSONEncoder
+
+	init() {
+		self.jsonEncoder = JSONEncoder()
+		jsonEncoder.outputFormatting = [.sortedKeys]
+	}
+
 	func encode(parameters: RequestParameter, in request: inout URLRequest) throws {
 		switch parameters {
 		case let .query(dictionary):
 			guard let queryItems = dictionary.asQueryItems else { return }
 			try add(queryItems, to: &request)
 
-		case let .body(encodale):
-			return
+		case let .body(encodable):
+			request.httpBody = try jsonEncoder.encode(encodable)
 		}
 	}
 

--- a/Sources/NetworkAPI/NetworkRequest.swift
+++ b/Sources/NetworkAPI/NetworkRequest.swift
@@ -7,3 +7,9 @@ public protocol NetworkRequest {
     var endpoint: Endpoint { get }
     var parameters: RequestParameter? { get }
 }
+
+// MARK: - Default Implementation
+
+public extension NetworkRequest {
+	var parameters: RequestParameter? { nil }
+}

--- a/Sources/NetworkAPI/ParametersEncoder.swift
+++ b/Sources/NetworkAPI/ParametersEncoder.swift
@@ -1,0 +1,6 @@
+import Foundation
+
+/// A type for encoding ``RequestParameters`` in an ``URLRequest``.
+public protocol ParametersEncoder {
+	func encode(parameters: RequestParameter, in request: inout URLRequest)
+}

--- a/Sources/NetworkAPI/ParametersEncoder.swift
+++ b/Sources/NetworkAPI/ParametersEncoder.swift
@@ -2,5 +2,5 @@ import Foundation
 
 /// A type for encoding ``RequestParameters`` in an ``URLRequest``.
 public protocol ParametersEncoder {
-	func encode(parameters: RequestParameter, in request: inout URLRequest)
+	func encode(parameters: RequestParameter, in request: inout URLRequest) throws
 }

--- a/Sources/NetworkAPI/ParametersEncoder.swift
+++ b/Sources/NetworkAPI/ParametersEncoder.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-/// A type for encoding ``RequestParameters`` in an ``URLRequest``.
+/// A type for encoding ``RequestParameter`` in an ``URLRequest``.
 public protocol ParametersEncoder {
 	func encode(parameters: RequestParameter, in request: inout URLRequest) throws
 }

--- a/Sources/NetworkAPI/RequestParameter.swift
+++ b/Sources/NetworkAPI/RequestParameter.swift
@@ -1,4 +1,7 @@
+import Foundation
+
 /// Parameters kind that can be specified on the request.
 public enum RequestParameter {
-    case query([String: Any])
+	case query([String: String])
+	case body(Encodable)
 }

--- a/Sources/NetworkMocks/Core/InoutParameterUpdater.swift
+++ b/Sources/NetworkMocks/Core/InoutParameterUpdater.swift
@@ -1,0 +1,4 @@
+import Foundation
+
+/// A closure to update an `inout` parameter.
+public typealias InoutParameterUpdater<T> = (inout T) -> Void

--- a/Sources/NetworkMocks/Core/ParametersEncoderMock.swift
+++ b/Sources/NetworkMocks/Core/ParametersEncoderMock.swift
@@ -1,0 +1,13 @@
+import Foundation
+import NetworkAPI
+
+public final class ParametersEncoderMock: ParametersEncoder {
+	public init() {}
+
+	public private(set) var encodeCallCount = 0
+	public private(set) var encodeParametersParameter: RequestParameter?
+	public func encode(parameters: RequestParameter, in request: inout URLRequest) {
+		encodeCallCount += 1
+		encodeParametersParameter = parameters
+	}
+}

--- a/Sources/NetworkMocks/Core/ParametersEncoderMock.swift
+++ b/Sources/NetworkMocks/Core/ParametersEncoderMock.swift
@@ -4,10 +4,16 @@ import NetworkAPI
 public final class ParametersEncoderMock: ParametersEncoder {
 	public init() {}
 
+	public var encodeRequestParameterUpdater: InoutParameterUpdater<URLRequest> = { _ in }
+	public var encodeError: Error?
 	public private(set) var encodeCallCount = 0
 	public private(set) var encodeParametersParameter: RequestParameter?
-	public func encode(parameters: RequestParameter, in request: inout URLRequest) {
+	public func encode(parameters: RequestParameter, in request: inout URLRequest) throws {
 		encodeCallCount += 1
 		encodeParametersParameter = parameters
+		if let encodeError {
+			throw encodeError
+		}
+		encodeRequestParameterUpdater(&request)
 	}
 }

--- a/Tests/NetworkTests/Core/StandardRequestParametersEncoderTests.swift
+++ b/Tests/NetworkTests/Core/StandardRequestParametersEncoderTests.swift
@@ -1,0 +1,40 @@
+import NetworkAPI
+import XCTest
+
+@testable import Network
+
+final class StandardRequestParametersEncoderTests: XCTestCase {
+	private var sut: StandardRequestParametersEncoder!
+
+	override func setUp() {
+		super.setUp()
+		sut = StandardRequestParametersEncoder()
+	}
+
+	override func tearDown() {
+		sut = nil
+		super.tearDown()
+	}
+
+	func testEncode_whenCalledWithQueryParameters_shouldEncodeQueryItemsInURLRequest() throws {
+		// Given
+		var urlRequest = try URLRequest(url: XCTUnwrap(URL(string: "google.com")))
+
+		// When
+		try sut.encode(parameters: .query(["size": 90, "color": "red"]), in: &urlRequest)
+
+		// Then
+		let encodedQueryItems = try XCTUnwrap(urlRequest.url.flatMap { URLComponents(url: $0, resolvingAgainstBaseURL: false)?.queryItems })
+		let expectedQueryParams = [URLQueryItem(name: "size", value: "90"), URLQueryItem(name: "color", value: "red")]
+		XCTAssertTrue(encodedQueryItems.allSatisfy(expectedQueryParams.contains(_:)))
+	}
+
+	func testEncode_whenCalledWithBodyParameter_shouldEncodeHTTPBodyInURLRequest() {
+		// Given
+
+		// When
+
+		// Then
+		XCTFail("Not Implemented")
+	}
+}

--- a/Tests/NetworkTests/Core/StandardRequestParametersEncoderTests.swift
+++ b/Tests/NetworkTests/Core/StandardRequestParametersEncoderTests.swift
@@ -21,7 +21,7 @@ final class StandardRequestParametersEncoderTests: XCTestCase {
 		var urlRequest = try URLRequest(url: XCTUnwrap(URL(string: "google.com")))
 
 		// When
-		try sut.encode(parameters: .query(["size": 90, "color": "red"]), in: &urlRequest)
+		try sut.encode(parameters: .query(["size": "90", "color": "red"]), in: &urlRequest)
 
 		// Then
 		let encodedQueryItems = try XCTUnwrap(urlRequest.url.flatMap { URLComponents(url: $0, resolvingAgainstBaseURL: false)?.queryItems })

--- a/Tests/NetworkTests/Core/StandardRequestParametersEncoderTests.swift
+++ b/Tests/NetworkTests/Core/StandardRequestParametersEncoderTests.swift
@@ -4,14 +4,14 @@ import XCTest
 @testable import Network
 
 final class StandardRequestParametersEncoderTests: XCTestCase {
-	private var jsonEncoder: JSONEncoder!
+	private var bodyEncoder: JSONEncoder!
 	private var sut: StandardRequestParametersEncoder!
 
 	override func setUp() {
 		super.setUp()
-		jsonEncoder = JSONEncoder()
-		jsonEncoder.outputFormatting = .sortedKeys
-		sut = StandardRequestParametersEncoder()
+		bodyEncoder = JSONEncoder()
+		bodyEncoder.outputFormatting = .sortedKeys // formatting the output will allow us to avoid boilerplate while asserting on expected body.
+		sut = StandardRequestParametersEncoder(bodyEncoder: bodyEncoder)
 	}
 
 	override func tearDown() {
@@ -41,7 +41,7 @@ final class StandardRequestParametersEncoderTests: XCTestCase {
 
 		// Then
 		let resultHTTPBody = try XCTUnwrap(urlRequest.httpBody)
-		let expectedBody = try jsonEncoder.encode("hello, world!")
+		let expectedBody = try bodyEncoder.encode("hello, world!")
 		XCTAssertEqual(resultHTTPBody, expectedBody)
 	}
 
@@ -59,7 +59,7 @@ final class StandardRequestParametersEncoderTests: XCTestCase {
 
 		// Then
 		let resultHTTPBody = try XCTUnwrap(urlRequest.httpBody)
-		let expectedBody = try jsonEncoder.encode(Beer(name: "Leffe", alchool: 7))
+		let expectedBody = try bodyEncoder.encode(Beer(name: "Leffe", alchool: 7))
 		XCTAssertEqual(resultHTTPBody, expectedBody)
 	}
 
@@ -77,7 +77,7 @@ final class StandardRequestParametersEncoderTests: XCTestCase {
 
 		// Then
 		let resultHTTPBody = try XCTUnwrap(urlRequest.httpBody)
-		let expectedBody = try jsonEncoder.encode([Beer(name: "Leffe", alchool: 7), Beer(name: "Estrella Galicia", alchool: 3)])
+		let expectedBody = try bodyEncoder.encode([Beer(name: "Leffe", alchool: 7), Beer(name: "Estrella Galicia", alchool: 3)])
 		XCTAssertEqual(resultHTTPBody, expectedBody)
 	}
 }


### PR DESCRIPTION
## Description
This PR adds support for body parameters in requests (see #2 for more details). 
Additionally added a build and test CI step for iOS platforms (see #9 for more details). 

## Related Issue
- closes #2 
- closes #9 